### PR TITLE
GitHub Action: Switch logic to bail out on a matching tag

### DIFF
--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -28,7 +28,7 @@ jobs:
           cd sdk/
           TAG=`git describe --tags`
           cd bower/
-          "`git log -1 --pretty=%B`" != "$TAG"
+          [ "`git log -1 --pretty=%B`" == "$TAG" ] && exit 1
 
       - name: Install Node (14.x)
         uses: actions/setup-node@v2


### PR DESCRIPTION
The way it stands now, it actually treats the conditional result as a command to execute :sweat_smile:, e.g.

```
/home/runner/work/_temp/afb56975-c141-4ff8-a9b8-3cc71af1c5ce.sh: line 4: 
Adds daily-running GHA to package Bower on new JS SDK releases (#8): command not found
```