### PR TITLE
Fix the Bower GitHub Action

### DIFF
--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'  # daily @ noon
-  pull_request:
 
 jobs:
   build-and-deploy:
@@ -61,4 +60,4 @@ jobs:
           git add .
           git commit -m $TAG
           git tag -a $TAG -m $TAG
-          # git push --atomic origin master "$TAG"
+          git push --atomic origin master "$TAG"

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'  # daily @ noon
+  pull_request:
 
 jobs:
   build-and-deploy:
@@ -14,21 +15,31 @@ jobs:
           repository: stellar/js-stellar-sdk
           fetch-depth: 0
           persist-credentials: false
-          path: sdk
 
       - name: Checkout Bower
         uses: actions/checkout@v2
         with:
           repository: stellar/bower-js-stellar-sdk
-          path: sdk/bower
+          fetch-depth: 0
+          ref: master
+          path: bower
 
+      # if this check fails then the job doesn't need to proceed
       - name: Check for updated SDK
-        # if this check fails then the job doesn't need to proceed
+        shell: bash
         run: |
-          cd sdk/
           TAG=`git describe --tags`
           cd bower/
-          [ "`git log -1 --pretty=%B`" == "$TAG" ] && exit 1
+          OLDTAG=`git describe --abbrev=0 --tags`
+          if [ "$OLDTAG" == "$TAG" ]; then
+            echo "No new JavaScript SDK version was found, skipping run."
+            exit 1
+          else
+            echo "::group::New JavaScript SDK version found:"
+            echo "Previous version: $OLDTAG"
+            echo "New version: $TAG"
+            echo "::endgroup::"
+          fi
 
       - name: Install Node (14.x)
         uses: actions/setup-node@v2
@@ -37,14 +48,12 @@ jobs:
 
       - name: Install and build package
         run: |
-          cd sdk
           yarn install
           yarn
           cp dist/* bower/
 
       - name: Publish package
         run: |
-          cd sdk/
           TAG=`git describe --tags`
           cd bower/
           git config user.name github-actions
@@ -52,4 +61,4 @@ jobs:
           git add .
           git commit -m $TAG
           git tag -a $TAG -m $TAG
-          git push --atomic origin master "$TAG"
+          # git push --atomic origin master "$TAG"


### PR DESCRIPTION
We can see that after allow the workflow to run on `pull_request`, it succeeded [here](https://github.com/stellar/bower-js-stellar-sdk/runs/5014517266?check_suite_focus=true), but did not push since I commented that out.

```
New JavaScript SDK version found:
  Previous version: v8.2.5
  New version: v10.0.1-1-g9f2aa47c
```

The latest commit, 2f95511, lets back in the real push so that it will occur once this is merged into master.